### PR TITLE
[Recipe] 레시피 수정 삭제 구현

### DIFF
--- a/src/main/java/gnu/project/pbl2/admin/dto/GeminiRecipeDto.java
+++ b/src/main/java/gnu/project/pbl2/admin/dto/GeminiRecipeDto.java
@@ -6,9 +6,7 @@ public record GeminiRecipeDto(
     String title,
     String categoryName,        // "한식", "양식" 등 — DB category.name과 매핑
     String tasteName,           // "매운맛" 등   — DB taste.name과 매핑
-    String difficulty,          // "EASY" | "MEDIUM" | "HARD"
     Integer cookTimeMin,
-    Integer calories,
     String description,
     List<IngredientDto> ingredients,
     List<String> steps

--- a/src/main/java/gnu/project/pbl2/recipe/controller/RecipeController.java
+++ b/src/main/java/gnu/project/pbl2/recipe/controller/RecipeController.java
@@ -4,6 +4,7 @@ import gnu.project.pbl2.auth.aop.Auth;
 import gnu.project.pbl2.auth.entity.Accessor;
 import gnu.project.pbl2.recipe.controller.docs.RecipeDocs;
 import gnu.project.pbl2.recipe.dto.request.RecipeSearchRequest;
+import gnu.project.pbl2.recipe.dto.request.RecipeUpdateRequest;
 import gnu.project.pbl2.recipe.dto.response.RecipeResponseDto;
 import gnu.project.pbl2.recipe.dto.response.RecipeSearchResponse;
 import gnu.project.pbl2.recipe.service.RecipeService;
@@ -11,9 +12,12 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,19 +28,39 @@ public class RecipeController implements RecipeDocs {
 
     private final RecipeService recipeService;
 
+    //TODO : 레시피 수정, 삭제 구현
     @GetMapping()
     public ResponseEntity<Page<RecipeSearchResponse>> getRecipes(
         @ModelAttribute @Valid final RecipeSearchRequest request,
         @Auth final Accessor accessor
     ) {
-        return ResponseEntity.ok(recipeService.getRecipes(request,accessor));
+        return ResponseEntity.ok(recipeService.getRecipes(request, accessor));
     }
+
     @GetMapping("/{id}")
     public ResponseEntity<RecipeResponseDto> getRecipe(
         @PathVariable(name = "id") final Long id,
         @Auth final Accessor accessor
     ) {
-        return ResponseEntity.ok(recipeService.getRecipeDetail(id,accessor));
+        return ResponseEntity.ok(recipeService.getRecipeDetail(id, accessor));
     }
 
+    // @OnlyAdmin
+    @DeleteMapping("{id}")
+    public ResponseEntity<Long> deleteRecipe(
+        @PathVariable(name = "id") final Long id,
+        @Auth final Accessor accessor
+    ) {
+        return ResponseEntity.ok(recipeService.deleteRecipe(id, accessor));
+    }
+
+    // @OnlyAdmin
+    @PatchMapping("{id}")
+    public ResponseEntity<Long> updateRecipe(
+        @PathVariable(name = "id") final Long id,
+        @RequestBody final RecipeUpdateRequest updateRequest,
+        @Auth final Accessor accessor
+    ) {
+        return ResponseEntity.ok(recipeService.updateRecipe(id, updateRequest, accessor));
+    }
 }

--- a/src/main/java/gnu/project/pbl2/recipe/controller/docs/RecipeDocs.java
+++ b/src/main/java/gnu/project/pbl2/recipe/controller/docs/RecipeDocs.java
@@ -2,6 +2,7 @@ package gnu.project.pbl2.recipe.controller.docs;
 
 import gnu.project.pbl2.auth.entity.Accessor;
 import gnu.project.pbl2.recipe.dto.request.RecipeSearchRequest;
+import gnu.project.pbl2.recipe.dto.request.RecipeUpdateRequest;
 import gnu.project.pbl2.recipe.dto.response.RecipeResponseDto;
 import gnu.project.pbl2.recipe.dto.response.RecipeSearchResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,24 +14,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Recipe", description = "레시피 API")
 public interface RecipeDocs {
 
     /**
-     * 레시피 목록 조회 ------- (1)
-     * <p>
-     * 키워드 및 탭 조건(전체, 조리 가능, 임박, 즐겨찾기)에 따라
-     * 레시피 목록을 페이징 형태로 조회한다.
-     * <p>
-     * - ALL: 전체 레시피 조회
-     * - COOKABLE: 보유 재료로 조리 가능한 레시피
-     * - EXPIRING: 임박 재료 포함 레시피
-     * - FAVORITE: 즐겨찾기 레시피
-     *
-     * @param request 검색 조건 (키워드, 탭, 페이지)
-     * @param accessor 인증된 사용자 정보
-     * @return 레시피 목록 (Page)
+     * 레시피 목록 조회
      */
     @Operation(
         summary = "레시피 목록 조회",
@@ -51,16 +41,6 @@ public interface RecipeDocs {
             responseCode = "200",
             description = "조회 성공",
             content = @Content(schema = @Schema(implementation = RecipeSearchResponse.class))
-        ),
-        @ApiResponse(
-            responseCode = "400",
-            description = "잘못된 요청 (페이지, 사이즈 등)",
-            content = @Content(schema = @Schema(hidden = true))
-        ),
-        @ApiResponse(
-            responseCode = "401",
-            description = "인증되지 않은 사용자",
-            content = @Content(schema = @Schema(hidden = true))
         )
     })
     ResponseEntity<Page<RecipeSearchResponse>> getRecipes(
@@ -72,53 +52,75 @@ public interface RecipeDocs {
     );
 
     /**
-     * 레시피 상세 조회 ------- (1)
-     * <p>
-     * 레시피 ID를 기반으로 상세 정보를 조회한다.
-     * <p>
-     * 반환 정보:
-     * - 기본 정보 (제목, 썸네일, 조리시간)
-     * - 재료 목록
-     * - 조리 단계
-     * - 카테고리 / 맛 정보
-     *
-     * @param id 레시피 ID
-     * @param accessor 인증된 사용자 정보
-     * @return 레시피 상세 정보
+     * 레시피 상세 조회
      */
     @Operation(
         summary = "레시피 상세 조회",
+        description = "레시피 ID를 기반으로 상세 정보를 조회합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "404", description = "레시피를 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<RecipeResponseDto> getRecipe(
+        @Parameter(description = "레시피 ID", example = "1")
+        Long id,
+
+        @Parameter(hidden = true)
+        Accessor accessor
+    );
+
+    /**
+     * 레시피 수정 (관리자 전용)
+     */
+    @Operation(
+        summary = "레시피 수정 (관리자)",
         description = """
-            레시피 ID를 기반으로 상세 정보를 조회합니다.
+            레시피 정보를 수정합니다. 
             
-            포함 정보:
-            - 레시피 기본 정보
-            - 재료 목록
-            - 조리 단계
-            - 카테고리 및 맛
-            
-            사용자 기준으로 즐겨찾기 여부도 포함될 수 있습니다.
+            **주의 사항:**
+            - 재료(ingredients)와 조리 단계(steps)는 기존 데이터를 삭제하고 전달받은 데이터로 **전체 교체**됩니다.
+            - 카테고리와 맛 정보는 전달된 이름을 기반으로 DB에서 찾아 연결합니다.
             """
     )
     @ApiResponses({
         @ApiResponse(
             responseCode = "200",
-            description = "조회 성공",
-            content = @Content(schema = @Schema(implementation = RecipeResponseDto.class))
+            description = "수정 성공",
+            content = @Content(schema = @Schema(implementation = Long.class))
         ),
-        @ApiResponse(
-            responseCode = "404",
-            description = "레시피를 찾을 수 없음",
-            content = @Content(schema = @Schema(hidden = true))
-        ),
-        @ApiResponse(
-            responseCode = "401",
-            description = "인증되지 않은 사용자",
-            content = @Content(schema = @Schema(hidden = true))
-        )
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "레시피를 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
-    ResponseEntity<RecipeResponseDto> getRecipe(
-        @Parameter(description = "레시피 ID", example = "1")
+    ResponseEntity<Long> updateRecipe(
+        @Parameter(description = "수정할 레시피 ID", example = "1")
+        Long id,
+
+        @RequestBody RecipeUpdateRequest updateRequest,
+
+        @Parameter(hidden = true)
+        Accessor accessor
+    );
+
+    /**
+     * 레시피 삭제 (관리자 전용)
+     */
+    @Operation(
+        summary = "레시피 삭제 (관리자)",
+        description = "레시피 ID를 기반으로 레시피를 삭제(상태 변경)합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "삭제 성공",
+            content = @Content(schema = @Schema(implementation = Long.class))
+        ),
+        @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "레시피를 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<Long> deleteRecipe(
+        @Parameter(description = "삭제할 레시피 ID", example = "1")
         Long id,
 
         @Parameter(hidden = true)

--- a/src/main/java/gnu/project/pbl2/recipe/dto/request/RecipeUpdateRequest.java
+++ b/src/main/java/gnu/project/pbl2/recipe/dto/request/RecipeUpdateRequest.java
@@ -1,0 +1,23 @@
+package gnu.project.pbl2.recipe.dto.request;
+
+import java.util.List;
+
+public record RecipeUpdateRequest(
+    String title,
+    String categoryName,
+    String tasteName,
+    Integer cookTimeMin,
+    String description,
+    List<IngredientDto> ingredients,
+    List<String> steps
+) {
+
+    public record IngredientDto(
+        String name,
+        String amount,
+        String unit,
+        boolean isSubstitutable
+    ) {
+
+    }
+}

--- a/src/main/java/gnu/project/pbl2/recipe/entity/Recipe.java
+++ b/src/main/java/gnu/project/pbl2/recipe/entity/Recipe.java
@@ -54,13 +54,13 @@ public class Recipe extends BaseEntity {
     @Column()
     private String thumbnailUrl;
 
-    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<RecipeStep> steps = new LinkedHashSet<>();
 
-    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<RecipeIngredient> ingredients = new LinkedHashSet<>();
 
-    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Favorite> favorites = new ArrayList<>();
     public static Recipe create(
         String title,
@@ -80,7 +80,28 @@ public class Recipe extends BaseEntity {
         return recipe;
     }
 
-    // ── 도메인 행위 ───────────────────────────────────────────
+
+    // 수정 로직 (정적 메서드가 아닌 인스턴스 메서드)
+    public void update(
+        String title,
+        Category category,
+        Taste taste,
+        Integer cookTimeMin,
+        String description
+    ) {
+        this.title = title;
+        this.category = category;
+        this.taste = taste;
+        this.cookTimeMin = cookTimeMin;
+        this.description = description;
+    }
+
+    // 기존 재료와 단계를 초기화하는 메서드
+    public void clearCollections() {
+        this.ingredients.clear();
+        this.steps.clear();
+    }
+
     public void addIngredients(List<RecipeIngredient> recipeIngredients) {
         this.ingredients.addAll(recipeIngredients);
     }

--- a/src/main/java/gnu/project/pbl2/recipe/entity/RecipeIngredient.java
+++ b/src/main/java/gnu/project/pbl2/recipe/entity/RecipeIngredient.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(of = "id", callSuper = false, onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(of = "id", callSuper = false)
 @Getter
 public class RecipeIngredient extends BaseEntity {
 

--- a/src/main/java/gnu/project/pbl2/recipe/entity/RecipeStep.java
+++ b/src/main/java/gnu/project/pbl2/recipe/entity/RecipeStep.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(of = "id", callSuper = false, onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(of = "id", callSuper = false)
 public class RecipeStep extends BaseEntity {
 
     @Id

--- a/src/main/java/gnu/project/pbl2/recipe/repository/impl/RecipeCustomRepositoryImpl.java
+++ b/src/main/java/gnu/project/pbl2/recipe/repository/impl/RecipeCustomRepositoryImpl.java
@@ -253,7 +253,7 @@ public class RecipeCustomRepositoryImpl implements RecipeCustomRepository {
             .leftJoin(recipe.taste).fetchJoin()
             .leftJoin(recipe.ingredients, recipeIngredient).fetchJoin()
             .leftJoin(recipeIngredient.ingredient).fetchJoin()
-            .where(recipe.id.eq(recipeId))
+            .where(recipe.id.eq(recipeId),recipe.isDeleted.eq(false))
             .fetchOne();
 
         if (result == null) {

--- a/src/main/java/gnu/project/pbl2/recipe/service/RecipeService.java
+++ b/src/main/java/gnu/project/pbl2/recipe/service/RecipeService.java
@@ -1,19 +1,30 @@
 package gnu.project.pbl2.recipe.service;
 
-import static gnu.project.pbl2.fridge.enumerated.FridgeStatus.*;
+import static gnu.project.pbl2.fridge.enumerated.FridgeStatus.ENOUGH;
+import static gnu.project.pbl2.fridge.enumerated.FridgeStatus.EXPIRING;
+import static gnu.project.pbl2.fridge.enumerated.FridgeStatus.NONE;
 
 import gnu.project.pbl2.auth.entity.Accessor;
+import gnu.project.pbl2.common.entity.Category;
+import gnu.project.pbl2.common.entity.Taste;
 import gnu.project.pbl2.common.error.ErrorCode;
 import gnu.project.pbl2.common.exception.BusinessException;
+import gnu.project.pbl2.common.repository.CategoryRepository;
+import gnu.project.pbl2.common.repository.TasteRepository;
 import gnu.project.pbl2.fridge.enumerated.FridgeStatus;
 import gnu.project.pbl2.fridge.repository.FridgeRepository;
+import gnu.project.pbl2.ingredient.entity.Ingredient;
+import gnu.project.pbl2.ingredient.repository.IngredientRepository;
 import gnu.project.pbl2.recipe.dto.request.RecipeSearchRequest;
+import gnu.project.pbl2.recipe.dto.request.RecipeUpdateRequest;
 import gnu.project.pbl2.recipe.dto.response.RecipeResponseDto;
 import gnu.project.pbl2.recipe.dto.response.RecipeSearchResponse;
 import gnu.project.pbl2.recipe.entity.Recipe;
+import gnu.project.pbl2.recipe.entity.RecipeIngredient;
 import gnu.project.pbl2.recipe.entity.RecipeStep;
 import gnu.project.pbl2.recipe.repository.RecipeRepository;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +42,9 @@ public class RecipeService {
 
     private final RecipeRepository recipeRepository;
     private final FridgeRepository fridgeRepository;
+    private final CategoryRepository categoryRepository;
+    private final TasteRepository tasteRepository;
+    private final IngredientRepository ingredientRepository;
 
     @Transactional(readOnly = true)
     public Page<RecipeSearchResponse> getRecipes(
@@ -130,5 +144,51 @@ public class RecipeService {
             return EXPIRING;
         }
         return ENOUGH;
+    }
+    @Transactional
+    public Long deleteRecipe(final Long id, final Accessor accessor) {
+        final Recipe recipe = recipeRepository.findDetailById(id)
+            .orElseThrow(() -> new BusinessException(ErrorCode.RECIPE_NOT_FOUND));
+        recipe.delete();
+        return recipe.getId();
+    }
+    @Transactional
+    public Long updateRecipe(final Long id,final RecipeUpdateRequest request,final Accessor accessor) {
+        Recipe recipe = recipeRepository.findById(id)
+            .orElseThrow(() -> new BusinessException(ErrorCode.RECIPE_NOT_FOUND));
+
+        Category category = categoryRepository.findByName(request.categoryName())
+            .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+        Taste taste = tasteRepository.findByName(request.tasteName())
+            .orElseThrow(() -> new BusinessException(ErrorCode.TASTE_NOT_FOUND));
+
+        recipe.update(
+            request.title(),
+            category,
+            taste,
+            request.cookTimeMin(),
+            request.description()
+        );
+
+        recipe.clearCollections();
+
+        List<RecipeIngredient> newIngredients = request.ingredients().stream()
+            .map(ingDto -> {
+                Ingredient ingredient = ingredientRepository.findByName(ingDto.name())
+                    .orElseGet(() -> ingredientRepository.save(Ingredient.create(ingDto.name(), category)));
+                return RecipeIngredient.of(recipe, ingredient, ingDto.amount(), ingDto.unit(), ingDto.isSubstitutable());
+            })
+            .toList();
+
+        List<RecipeStep> newSteps = new ArrayList<>();
+
+        for (int i = 0; i < request.steps().size(); i++) {
+            newSteps.add(RecipeStep.of(recipe, i + 1, request.steps().get(i)));
+        }
+
+        recipe.addIngredients(newIngredients);
+        recipe.addSteps(newSteps);
+
+        return recipe.getId();
     }
 }

--- a/src/main/java/gnu/project/pbl2/recipe/service/RecipeService.java
+++ b/src/main/java/gnu/project/pbl2/recipe/service/RecipeService.java
@@ -3,6 +3,7 @@ package gnu.project.pbl2.recipe.service;
 import static gnu.project.pbl2.fridge.enumerated.FridgeStatus.ENOUGH;
 import static gnu.project.pbl2.fridge.enumerated.FridgeStatus.EXPIRING;
 import static gnu.project.pbl2.fridge.enumerated.FridgeStatus.NONE;
+import static gnu.project.pbl2.recipe.dto.response.RecipeResponseDto.*;
 
 import gnu.project.pbl2.auth.entity.Accessor;
 import gnu.project.pbl2.common.entity.Category;
@@ -22,7 +23,9 @@ import gnu.project.pbl2.recipe.dto.response.RecipeSearchResponse;
 import gnu.project.pbl2.recipe.entity.Recipe;
 import gnu.project.pbl2.recipe.entity.RecipeIngredient;
 import gnu.project.pbl2.recipe.entity.RecipeStep;
+import gnu.project.pbl2.recipe.repository.RecipeIngredientRepository;
 import gnu.project.pbl2.recipe.repository.RecipeRepository;
+import gnu.project.pbl2.recipe.repository.RecipeStepRepository;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -45,6 +48,8 @@ public class RecipeService {
     private final CategoryRepository categoryRepository;
     private final TasteRepository tasteRepository;
     private final IngredientRepository ingredientRepository;
+    private final RecipeIngredientRepository recipeIngredientRepository;
+    private final RecipeStepRepository recipeStepRepository;
 
     @Transactional(readOnly = true)
     public Page<RecipeSearchResponse> getRecipes(
@@ -94,9 +99,9 @@ public class RecipeService {
         Set<Long> expiringIngredientIds = fridgeRepository
             .findExpiringIngredientIds(userId, LocalDate.now().plusDays(3));
 
-        List<RecipeResponseDto.RecipeIngredientDetail> ingredients =
+        List<RecipeIngredientDetail> ingredients =
             foundRecipe.getIngredients().stream()
-                .map(ri -> new RecipeResponseDto.RecipeIngredientDetail(
+                .map(ri -> new RecipeIngredientDetail(
                     ri.getIngredient().getId(),
                     ri.getIngredient().getName(),
                     ri.getAmount(),
@@ -110,10 +115,10 @@ public class RecipeService {
                 ))
                 .toList();
 
-        List<RecipeResponseDto.RecipeStepDetail> steps =
+        List<RecipeStepDetail> steps =
             foundRecipe.getSteps().stream()
                 .sorted(Comparator.comparingInt(RecipeStep::getStepOrder))
-                .map(s -> new RecipeResponseDto.RecipeStepDetail(
+                .map(s -> new RecipeStepDetail(
                     s.getStepOrder(),
                     s.getDescription()
                 ))
@@ -145,6 +150,7 @@ public class RecipeService {
         }
         return ENOUGH;
     }
+
     @Transactional
     public Long deleteRecipe(final Long id, final Accessor accessor) {
         final Recipe recipe = recipeRepository.findDetailById(id)
@@ -152,8 +158,13 @@ public class RecipeService {
         recipe.delete();
         return recipe.getId();
     }
+
     @Transactional
-    public Long updateRecipe(final Long id,final RecipeUpdateRequest request,final Accessor accessor) {
+    public Long updateRecipe(
+        final Long id,
+        final RecipeUpdateRequest request,
+        final Accessor accessor
+    ) {
         Recipe recipe = recipeRepository.findById(id)
             .orElseThrow(() -> new BusinessException(ErrorCode.RECIPE_NOT_FOUND));
 
@@ -175,15 +186,19 @@ public class RecipeService {
         List<RecipeIngredient> newIngredients = request.ingredients().stream()
             .map(ingDto -> {
                 Ingredient ingredient = ingredientRepository.findByName(ingDto.name())
-                    .orElseGet(() -> ingredientRepository.save(Ingredient.create(ingDto.name(), category)));
-                return RecipeIngredient.of(recipe, ingredient, ingDto.amount(), ingDto.unit(), ingDto.isSubstitutable());
+                    .orElseGet(() -> ingredientRepository.save(
+                        Ingredient.create(ingDto.name(), category)));
+                return recipeIngredientRepository.save(
+                    RecipeIngredient.of(recipe, ingredient, ingDto.amount(), ingDto.unit(),
+                        ingDto.isSubstitutable()));
             })
             .toList();
 
         List<RecipeStep> newSteps = new ArrayList<>();
 
         for (int i = 0; i < request.steps().size(); i++) {
-            newSteps.add(RecipeStep.of(recipe, i + 1, request.steps().get(i)));
+            newSteps.add(
+                recipeStepRepository.save(RecipeStep.of(recipe, i + 1, request.steps().get(i))));
         }
 
         recipe.addIngredients(newIngredients);


### PR DESCRIPTION

## 📌 관련 이슈

> #18

---

## 🛠 작업 내용

### 1. 레시피 수정 / 삭제 기능 추가

* `PATCH /recipes/{id}` 레시피 수정 API 추가
* `DELETE /recipes/{id}` 레시피 삭제 API 추가
* 관리자 전용 기능으로 설계 (추후 권한 어노테이션 적용 예정)

---

### 2. Recipe 도메인 중심으로 책임 이동

* 레시피 수정 로직을 `Recipe` 엔티티의 도메인 메서드로 이동

  * `update(...)` 메서드 추가
* 컬렉션 변경 로직 분리

  * `clearCollections()` → 기존 재료/단계 초기화
  * `addIngredients(...)`, `addSteps(...)` → 재구성

---

### 3. 연관관계 정리 및 orphanRemoval 적용

* `Recipe` ↔ `RecipeIngredient`, `RecipeStep`, `Favorite`

```java
orphanRemoval = true
```


---

### 4. 레시피 수정 로직 구현

* 카테고리 / 맛 이름 기반 조회 후 매핑
* 재료:

  * 이름 기준 조회
  * 없으면 생성 후 저장
* 조리 단계:

  * 순서 기반 재생성


---

### 5. Soft Delete 적용

* `recipe.delete()` 호출 방식으로 삭제 처리
* 조회 시 `isDeleted = false` 조건 추가

```java
.where(recipe.id.eq(recipeId), recipe.isDeleted.eq(false))
```

---

### 6. API 응답 구조 정리

* 수정/삭제 API → `Long (id)` 반환
* 불필요한 상세 DTO 생성 제거

---

### 7. 기타 정리

* Swagger Docs (`RecipeDocs`)에 수정/삭제 API 명세 추가
* 불필요한 필드 제거 (`GeminiRecipeDto` calories 삭제)

---


* 레시피 수정/삭제는 **Recipe 도메인의 책임**
* Controller는 요청 전달
* Service는 흐름 제어
* Entity는 상태 변경 담당

---

## 📎 ETC

* 수정 시 연관 엔티티를 “부분 업데이트”가 아닌
  **전체 교체 방식**으로 처리 (복잡도 감소 목적)
* 관리자 권한 체크는 추후 `@OnlyAdmin` 또는 Security 기반으로 분리 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 레시피 업데이트: 제목·카테고리·맛·조리시간·설명·재료·단계를 수정할 수 있습니다.
  * 레시피 삭제: 레시피를 삭제할 수 있습니다.

* **문서**
  * API 문서 갱신: 레시피 조회·업데이트·삭제 엔드포인트의 응답 코드 및 설명 정리.

* **변경 사항**
  * 레시피 응답에서 difficulty 및 calories 필드 제거 (응답 형식 변경).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->