### PR TITLE
[Notification]  알림 구현

### DIFF
--- a/src/main/java/gnu/project/pbl2/common/config/SchedulingConfig.java
+++ b/src/main/java/gnu/project/pbl2/common/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package gnu.project.pbl2.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/gnu/project/pbl2/common/error/ErrorCode.java
+++ b/src/main/java/gnu/project/pbl2/common/error/ErrorCode.java
@@ -38,7 +38,10 @@ public enum ErrorCode {
     STORAGE_METHOD_NOT_FOUND(HttpStatus.NOT_FOUND, "STORAGE4042", "해당 보관 방법을 찾을 수 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "STORAGE4043", "해당 카테고리를 찾을 수 없습니다."),
 
-    TASTE_NOT_FOUND(HttpStatus.NOT_FOUND,"TASTE7001", "해당 맛을 찾을 수 없습니다");
+    TASTE_NOT_FOUND(HttpStatus.NOT_FOUND,"TASTE7001", "해당 맛을 찾을 수 없습니다"),
+
+    // notification
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI8001", "해당 알림을 찾을 수 없습니다.");
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/gnu/project/pbl2/fridge/repository/FridgeRepository.java
+++ b/src/main/java/gnu/project/pbl2/fridge/repository/FridgeRepository.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.EntityGraph;
 
 public interface FridgeRepository extends JpaRepository<Fridge, Long> {
 
@@ -23,4 +24,8 @@ public interface FridgeRepository extends JpaRepository<Fridge, Long> {
 
     /** 재료 사용 여부 확인 */
     boolean existsByIngredient_Id(Long ingredientId);
+
+    @EntityGraph(attributePaths = {"member", "ingredient"})
+    @Query("SELECT f FROM Fridge f WHERE f.expiryDate IS NOT NULL AND f.expiryDate <= :threshold")
+    List<Fridge> findAllExpiringFridgeItems(@Param("threshold") LocalDate threshold);
 }

--- a/src/main/java/gnu/project/pbl2/fridge/repository/FridgeRepository.java
+++ b/src/main/java/gnu/project/pbl2/fridge/repository/FridgeRepository.java
@@ -4,10 +4,10 @@ import gnu.project.pbl2.fridge.entity.Fridge;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.data.jpa.repository.EntityGraph;
 
 public interface FridgeRepository extends JpaRepository<Fridge, Long> {
 

--- a/src/main/java/gnu/project/pbl2/notification/controller/NotificationController.java
+++ b/src/main/java/gnu/project/pbl2/notification/controller/NotificationController.java
@@ -1,0 +1,44 @@
+package gnu.project.pbl2.notification.controller;
+
+import gnu.project.pbl2.auth.aop.Auth;
+import gnu.project.pbl2.auth.entity.Accessor;
+import gnu.project.pbl2.notification.controller.docs.NotificationControllerDocs;
+import gnu.project.pbl2.notification.dto.response.NotificationResponse;
+import gnu.project.pbl2.notification.service.NotificationService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class NotificationController implements NotificationControllerDocs {
+
+    private final NotificationService notificationService;
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@Auth Accessor accessor) {
+        return notificationService.subscribe(accessor.getUserId());
+    }
+
+    @GetMapping
+    public ResponseEntity<List<NotificationResponse>> getNotifications(@Auth Accessor accessor) {
+        return ResponseEntity.ok(notificationService.getNotifications(accessor.getUserId()));
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<Void> markAsRead(
+        @PathVariable Long notificationId,
+        @Auth Accessor accessor
+    ) {
+        notificationService.markAsRead(notificationId, accessor.getUserId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/gnu/project/pbl2/notification/controller/NotificationController.java
+++ b/src/main/java/gnu/project/pbl2/notification/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package gnu.project.pbl2.notification.controller;
 
 import gnu.project.pbl2.auth.aop.Auth;
+import gnu.project.pbl2.auth.aop.OnlyUser;
 import gnu.project.pbl2.auth.entity.Accessor;
 import gnu.project.pbl2.notification.controller.docs.NotificationControllerDocs;
 import gnu.project.pbl2.notification.dto.response.NotificationResponse;
@@ -23,16 +24,19 @@ public class NotificationController implements NotificationControllerDocs {
 
     private final NotificationService notificationService;
 
+    @OnlyUser
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@Auth Accessor accessor) {
         return notificationService.subscribe(accessor.getUserId());
     }
 
+    @OnlyUser
     @GetMapping
     public ResponseEntity<List<NotificationResponse>> getNotifications(@Auth Accessor accessor) {
         return ResponseEntity.ok(notificationService.getNotifications(accessor.getUserId()));
     }
 
+    @OnlyUser
     @PatchMapping("/{notificationId}/read")
     public ResponseEntity<Void> markAsRead(
         @PathVariable Long notificationId,

--- a/src/main/java/gnu/project/pbl2/notification/controller/NotificationTestController.java
+++ b/src/main/java/gnu/project/pbl2/notification/controller/NotificationTestController.java
@@ -1,0 +1,31 @@
+package gnu.project.pbl2.notification.controller;
+
+import gnu.project.pbl2.notification.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Notification Test", description = "알림 테스트용 API (local 환경 전용)")
+@Profile("local")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/test/notifications")
+public class NotificationTestController {
+
+    private final NotificationService notificationService;
+
+    @Operation(
+        summary = "유통기한 알림 수동 실행",
+        description = "스케줄러(매일 오전 9시)를 즉시 수동으로 실행합니다. local 환경에서만 동작합니다."
+    )
+    @PostMapping("/trigger")
+    public ResponseEntity<String> triggerExpiryNotifications() {
+        notificationService.checkAndSendExpiryNotifications();
+        return ResponseEntity.ok("유통기한 알림 스캔이 완료되었습니다.");
+    }
+}

--- a/src/main/java/gnu/project/pbl2/notification/controller/docs/NotificationControllerDocs.java
+++ b/src/main/java/gnu/project/pbl2/notification/controller/docs/NotificationControllerDocs.java
@@ -1,0 +1,64 @@
+package gnu.project.pbl2.notification.controller.docs;
+
+import gnu.project.pbl2.auth.entity.Accessor;
+import gnu.project.pbl2.notification.dto.response.NotificationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Tag(name = "Notification", description = "알림 API")
+public interface NotificationControllerDocs {
+
+    @Operation(
+        summary = "SSE 알림 구독",
+        description = """
+            SSE 연결을 통해 유통기한 임박 알림을 실시간으로 수신합니다.
+
+            - 연결 직후 미읽은 알림이 즉시 전송됩니다.
+            - 매일 오전 9시에 유통기한 3일 이내 재료에 대한 알림이 발송됩니다.
+            - 이벤트 타입: `connect` (연결 확인), `notification` (알림)
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "SSE 연결 성공")
+    })
+    SseEmitter subscribe(
+        @Parameter(hidden = true) Accessor accessor
+    );
+
+    @Operation(
+        summary = "알림 목록 조회",
+        description = "로그인한 사용자의 전체 알림 목록을 최신순으로 반환합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = NotificationResponse.class))
+        )
+    })
+    ResponseEntity<List<NotificationResponse>> getNotifications(
+        @Parameter(hidden = true) Accessor accessor
+    );
+
+    @Operation(
+        summary = "알림 읽음 처리",
+        description = "특정 알림을 읽음 상태로 변경합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "읽음 처리 성공"),
+        @ApiResponse(responseCode = "403", description = "다른 사용자의 알림", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "알림을 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<Void> markAsRead(
+        @Parameter(description = "알림 ID", example = "1") Long notificationId,
+        @Parameter(hidden = true) Accessor accessor
+    );
+}

--- a/src/main/java/gnu/project/pbl2/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/gnu/project/pbl2/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,27 @@
+package gnu.project.pbl2.notification.dto.response;
+
+import gnu.project.pbl2.notification.entity.Notification;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+public record NotificationResponse(
+    Long notificationId,
+    String ingredientName,
+    LocalDate expiryDate,
+    long daysUntilExpiry,
+    boolean isRead,
+    LocalDateTime createdAt
+) {
+
+    public static NotificationResponse from(Notification notification) {
+        return new NotificationResponse(
+            notification.getId(),
+            notification.getIngredientName(),
+            notification.getExpiryDate(),
+            ChronoUnit.DAYS.between(LocalDate.now(), notification.getExpiryDate()),
+            notification.isRead(),
+            notification.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/gnu/project/pbl2/notification/entity/Notification.java
+++ b/src/main/java/gnu/project/pbl2/notification/entity/Notification.java
@@ -1,0 +1,57 @@
+package gnu.project.pbl2.notification.entity;
+
+import gnu.project.pbl2.common.entity.BaseEntity;
+import gnu.project.pbl2.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "notification")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private User member;
+
+    @Column(name = "ingredient_name", nullable = false, length = 100)
+    private String ingredientName;
+
+    @Column(name = "expiry_date", nullable = false)
+    private LocalDate expiryDate;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead;
+
+    private Notification(User member, String ingredientName, LocalDate expiryDate) {
+        this.member = member;
+        this.ingredientName = ingredientName;
+        this.expiryDate = expiryDate;
+        this.isRead = false;
+    }
+
+    public static Notification create(User member, String ingredientName, LocalDate expiryDate) {
+        return new Notification(member, ingredientName, expiryDate);
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+}

--- a/src/main/java/gnu/project/pbl2/notification/repository/NotificationRepository.java
+++ b/src/main/java/gnu/project/pbl2/notification/repository/NotificationRepository.java
@@ -1,0 +1,27 @@
+package gnu.project.pbl2.notification.repository;
+
+import gnu.project.pbl2.notification.entity.Notification;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("SELECT n FROM Notification n WHERE n.member.id = :userId AND n.isRead = false AND n.isDeleted = false ORDER BY n.createdAt DESC")
+    List<Notification> findUnreadByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT n FROM Notification n WHERE n.member.id = :userId AND n.isDeleted = false ORDER BY n.createdAt DESC")
+    List<Notification> findAllByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT CASE WHEN COUNT(n) > 0 THEN TRUE ELSE FALSE END FROM Notification n "
+        + "WHERE n.member.id = :userId AND n.ingredientName = :ingredientName "
+        + "AND n.createdAt >= :startOfDay AND n.createdAt < :endOfDay AND n.isDeleted = false")
+    boolean existsTodayNotification(
+        @Param("userId") Long userId,
+        @Param("ingredientName") String ingredientName,
+        @Param("startOfDay") LocalDateTime startOfDay,
+        @Param("endOfDay") LocalDateTime endOfDay
+    );
+}

--- a/src/main/java/gnu/project/pbl2/notification/repository/SseEmitterRepository.java
+++ b/src/main/java/gnu/project/pbl2/notification/repository/SseEmitterRepository.java
@@ -1,0 +1,25 @@
+package gnu.project.pbl2.notification.repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+public class SseEmitterRepository {
+
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public void save(Long userId, SseEmitter emitter) {
+        emitters.put(userId, emitter);
+    }
+
+    public Optional<SseEmitter> findById(Long userId) {
+        return Optional.ofNullable(emitters.get(userId));
+    }
+
+    public void delete(Long userId) {
+        emitters.remove(userId);
+    }
+}

--- a/src/main/java/gnu/project/pbl2/notification/repository/SseEmitterRepository.java
+++ b/src/main/java/gnu/project/pbl2/notification/repository/SseEmitterRepository.java
@@ -12,7 +12,10 @@ public class SseEmitterRepository {
     private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
 
     public void save(Long userId, SseEmitter emitter) {
-        emitters.put(userId, emitter);
+        SseEmitter old = emitters.put(userId, emitter);
+        if (old != null) {
+            old.complete();
+        }
     }
 
     public Optional<SseEmitter> findById(Long userId) {

--- a/src/main/java/gnu/project/pbl2/notification/service/NotificationService.java
+++ b/src/main/java/gnu/project/pbl2/notification/service/NotificationService.java
@@ -1,0 +1,104 @@
+package gnu.project.pbl2.notification.service;
+
+import gnu.project.pbl2.common.error.ErrorCode;
+import gnu.project.pbl2.common.exception.AuthException;
+import gnu.project.pbl2.common.exception.NotFoundException;
+import gnu.project.pbl2.fridge.repository.FridgeRepository;
+import gnu.project.pbl2.notification.dto.response.NotificationResponse;
+import gnu.project.pbl2.notification.entity.Notification;
+import gnu.project.pbl2.notification.repository.NotificationRepository;
+import gnu.project.pbl2.notification.repository.SseEmitterRepository;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+
+    private static final long SSE_TIMEOUT = 60L * 60 * 1000; // 1시간
+    private static final int EXPIRY_THRESHOLD_DAYS = 3;
+
+    private final NotificationRepository notificationRepository;
+    private final SseEmitterRepository sseEmitterRepository;
+    private final FridgeRepository fridgeRepository;
+
+    public SseEmitter subscribe(Long userId) {
+        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT);
+        sseEmitterRepository.save(userId, emitter);
+
+        emitter.onCompletion(() -> sseEmitterRepository.delete(userId));
+        emitter.onTimeout(() -> sseEmitterRepository.delete(userId));
+        emitter.onError(e -> sseEmitterRepository.delete(userId));
+
+        sendToEmitter(emitter, userId, "connect", "연결이 완료되었습니다.");
+
+        notificationRepository.findUnreadByUserId(userId)
+            .forEach(n -> sendToEmitter(emitter, userId, "notification", NotificationResponse.from(n)));
+
+        return emitter;
+    }
+
+    public List<NotificationResponse> getNotifications(Long userId) {
+        return notificationRepository.findAllByUserId(userId)
+            .stream()
+            .map(NotificationResponse::from)
+            .toList();
+    }
+
+    @Transactional
+    @Scheduled(cron = "0 0 9 * * *")
+    public void checkAndSendExpiryNotifications() {
+        LocalDate threshold = LocalDate.now().plusDays(EXPIRY_THRESHOLD_DAYS);
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+
+        fridgeRepository.findAllExpiringFridgeItems(threshold).forEach(fridge -> {
+            Long userId = fridge.getMember().getId();
+            String ingredientName = fridge.getIngredient().getName();
+
+            if (notificationRepository.existsTodayNotification(userId, ingredientName, startOfDay, endOfDay)) {
+                return;
+            }
+
+            Notification notification = Notification.create(
+                fridge.getMember(), ingredientName, fridge.getExpiryDate()
+            );
+            notificationRepository.save(notification);
+
+            sseEmitterRepository.findById(userId).ifPresent(emitter ->
+                sendToEmitter(emitter, userId, "notification", NotificationResponse.from(notification)));
+        });
+    }
+
+    @Transactional
+    public void markAsRead(Long notificationId, Long userId) {
+        Notification notification = notificationRepository.findById(notificationId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.getMember().getId().equals(userId)) {
+            throw new AuthException(ErrorCode.AUTH_FORBIDDEN);
+        }
+
+        notification.markAsRead();
+    }
+
+    private void sendToEmitter(SseEmitter emitter, Long userId, String eventName, Object data) {
+        try {
+            emitter.send(SseEmitter.event().name(eventName).data(data));
+        } catch (IOException e) {
+            log.warn("SSE 전송 실패 - userId: {}", userId);
+            sseEmitterRepository.delete(userId);
+            emitter.completeWithError(e);
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
> #24

## 작업 내용

- 유통기한 임박 알림 기능 전체 구현
  - 매일 오전 9시에 유통기한 3일 이내 재료에 대한 알림 자동 발송
  - SSE(Server-Sent Events)를 이용한 실시간 알림 구독 기능 추가
  - 알림 목록 조회 및 개별 알림 읽음 처리 API 구현

### 주요 변경사항

**1. 설정 및 인프라**
- `SchedulingConfig` 추가 (`@EnableScheduling` 활성화)

**2. 알림 도메인**
- `Notification` 엔티티 추가 (회원, 재료명, 유통기한, 읽음 상태 관리)
- `NotificationRepository` 구현 (오늘 이미 보낸 알림 중복 방지 로직 포함)
- `SseEmitterRepository` 구현 (동시성 안전한 SSE 연결 관리)

**3. 알림 서비스**
- `NotificationService`
  - SSE 구독 (`subscribe`)
  - 연결 시 미읽은 알림 즉시 전송
  - `checkAndSendExpiryNotifications()` 스케줄러 구현 (cron: 매일 오전 9시)
  - 알림 중복 방지 로직 (하루 1회 동일 재료에 대해 알림 제한)
  - 알림 읽음 처리

**4. API**
- `NotificationController`
  - `GET /api/v1/notifications/subscribe` : SSE 실시간 알림 구독
  - `GET /api/v1/notifications` : 알림 목록 조회
  - `PATCH /api/v1/notifications/{notificationId}/read` : 알림 읽음 처리
- `NotificationTestController` (local 프로파일 전용)
  - `POST /api/v1/test/notifications/trigger` : 유통기한 알림 수동 트리거

**5. 기타**
- `ErrorCode`에 `NOTIFICATION_NOT_FOUND` 추가
- `FridgeRepository`에 만료 임박 재료 조회 메서드 추가 (`findAllExpiringFridgeItems`)
- Swagger 문서화 (`NotificationControllerDocs`)

## ETC
- SSE 연결 타임아웃: 1시간
- 알림 발송 기준: 유통기한 D-3 이내
- 동일 재료에 대해 하루에 한 번만 알림 전송되도록 중복 방지 로직 적용
- local 환경에서는 `/trigger` API로 즉시 알림 테스트 가능

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 냉장고 식재료 만료 알림 시스템 추가
  * 실시간 알림(구독) 수신 기능 추가 (SSE)
  * 사용자별 알림 목록 조회 기능 추가
  * 알림 읽음 상태 표시/변경 기능 추가
  * 일일 자동 만료 예정 식재료 알림 생성 및 전송 예약 작업 추가
  * 알림 응답에 만료까지 남은 일수 표시 추가

* **문서**
  * 알림 API용 Swagger 문서 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->