### PR TITLE
[Recipe] 즐겨찾기 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -68,6 +69,9 @@ dependencies {
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    // mockito
+    testImplementation 'org.mockito:mockito-core:5.11.0'
 
 }
 

--- a/src/main/java/gnu/project/pbl2/common/error/ErrorCode.java
+++ b/src/main/java/gnu/project/pbl2/common/error/ErrorCode.java
@@ -34,6 +34,8 @@ public enum ErrorCode {
     RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND,"RECIPE6001" ,"해당 레시피를 찾을 수 없습니다" ),
     RECIPE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST,"RECIPE6002" ,"해당 레시피가 이미 존재합니다." ),
     RECIPE_IMPORT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RECIPE6003", "레시피 분석에 실패했습니다."),
+    FAVORITE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "RECIPE6004", "이미 즐겨찾기한 레시피입니다."),
+    FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "RECIPE6005", "즐겨찾기를 찾을 수 없습니다."),
     INGREDIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "STORAGE4041", "해당 재료를 찾을 수 없습니다."),
     STORAGE_METHOD_NOT_FOUND(HttpStatus.NOT_FOUND, "STORAGE4042", "해당 보관 방법을 찾을 수 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "STORAGE4043", "해당 카테고리를 찾을 수 없습니다."),

--- a/src/main/java/gnu/project/pbl2/notification/entity/Notification.java
+++ b/src/main/java/gnu/project/pbl2/notification/entity/Notification.java
@@ -11,13 +11,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "notification")
+@Table(
+    name = "notification",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "ingredient_name", "expiry_date"})
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {

--- a/src/main/java/gnu/project/pbl2/notification/repository/SseEmitterRepository.java
+++ b/src/main/java/gnu/project/pbl2/notification/repository/SseEmitterRepository.java
@@ -12,10 +12,12 @@ public class SseEmitterRepository {
     private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
 
     public void save(Long userId, SseEmitter emitter) {
-        SseEmitter old = emitters.put(userId, emitter);
-        if (old != null) {
-            old.complete();
-        }
+        emitters.compute(userId, (id, old) -> {
+            if (old != null) {
+                old.complete();
+            }
+            return emitter;
+        });
     }
 
     public Optional<SseEmitter> findById(Long userId) {

--- a/src/main/java/gnu/project/pbl2/recipe/controller/FavoriteController.java
+++ b/src/main/java/gnu/project/pbl2/recipe/controller/FavoriteController.java
@@ -1,0 +1,58 @@
+package gnu.project.pbl2.recipe.controller;
+
+import gnu.project.pbl2.auth.aop.Auth;
+import gnu.project.pbl2.auth.aop.OnlyUser;
+import gnu.project.pbl2.auth.entity.Accessor;
+import gnu.project.pbl2.recipe.controller.docs.FavoriteDocs;
+import gnu.project.pbl2.recipe.dto.request.FavoriteListRequest;
+import gnu.project.pbl2.recipe.dto.response.RecipeSearchResponse;
+import gnu.project.pbl2.recipe.service.FavoriteService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/recipes")
+public class FavoriteController implements FavoriteDocs {
+
+    private final FavoriteService favoriteService;
+
+    @OnlyUser
+    @PostMapping("/{recipeId}/favorites")
+    public ResponseEntity<Void> addFavorite(
+        @PathVariable final Long recipeId,
+        @Auth final Accessor accessor
+    ) {
+        favoriteService.add(recipeId, accessor);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @OnlyUser
+    @DeleteMapping("/{recipeId}/favorites")
+    public ResponseEntity<Void> removeFavorite(
+        @PathVariable final Long recipeId,
+        @Auth final Accessor accessor
+    ) {
+        favoriteService.remove(recipeId, accessor);
+        return ResponseEntity.noContent().build();
+    }
+
+    @OnlyUser
+    @GetMapping("/favorites")
+    public ResponseEntity<Page<RecipeSearchResponse>> getFavorites(
+        @ModelAttribute @Valid final FavoriteListRequest request,
+        @Auth final Accessor accessor
+    ) {
+        return ResponseEntity.ok(favoriteService.getFavorites(request, accessor));
+    }
+}

--- a/src/main/java/gnu/project/pbl2/recipe/controller/docs/FavoriteDocs.java
+++ b/src/main/java/gnu/project/pbl2/recipe/controller/docs/FavoriteDocs.java
@@ -1,0 +1,58 @@
+package gnu.project.pbl2.recipe.controller.docs;
+
+import gnu.project.pbl2.auth.entity.Accessor;
+import gnu.project.pbl2.recipe.dto.request.FavoriteListRequest;
+import gnu.project.pbl2.recipe.dto.response.RecipeSearchResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Favorite", description = "즐겨찾기 API")
+public interface FavoriteDocs {
+
+    @Operation(summary = "즐겨찾기 추가", description = "레시피를 즐겨찾기에 추가합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "추가 성공"),
+        @ApiResponse(responseCode = "400", description = "이미 즐겨찾기한 레시피", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "레시피를 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<Void> addFavorite(
+        @Parameter(description = "레시피 ID", example = "1") Long recipeId,
+        @Parameter(hidden = true) Accessor accessor
+    );
+
+    @Operation(summary = "즐겨찾기 삭제", description = "레시피를 즐겨찾기에서 삭제합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "삭제 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "즐겨찾기를 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<Void> removeFavorite(
+        @Parameter(description = "레시피 ID", example = "1") Long recipeId,
+        @Parameter(hidden = true) Accessor accessor
+    );
+
+    @Operation(
+        summary = "즐겨찾기 목록 조회",
+        description = "내가 즐겨찾기한 레시피 목록을 페이지네이션으로 조회합니다. 조리가능·임박재료 뱃지도 함께 반환됩니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = RecipeSearchResponse.class))
+        ),
+        @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<Page<RecipeSearchResponse>> getFavorites(
+        @Parameter(description = "즐겨찾기 목록 조회 조건") FavoriteListRequest request,
+        @Parameter(hidden = true) Accessor accessor
+    );
+}

--- a/src/main/java/gnu/project/pbl2/recipe/dto/request/FavoriteListRequest.java
+++ b/src/main/java/gnu/project/pbl2/recipe/dto/request/FavoriteListRequest.java
@@ -1,0 +1,16 @@
+package gnu.project.pbl2.recipe.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record FavoriteListRequest(
+    String keyword,
+    @Min(0) int page,
+    @Min(6) @Max(20) int size
+) {
+    public FavoriteListRequest {
+        if (size == 0) {
+            size = 10;
+        }
+    }
+}

--- a/src/main/java/gnu/project/pbl2/recipe/entity/Favorite.java
+++ b/src/main/java/gnu/project/pbl2/recipe/entity/Favorite.java
@@ -9,11 +9,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "recipe_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Favorite extends BaseEntity {

--- a/src/main/java/gnu/project/pbl2/recipe/repository/FavoriteRepository.java
+++ b/src/main/java/gnu/project/pbl2/recipe/repository/FavoriteRepository.java
@@ -1,0 +1,10 @@
+package gnu.project.pbl2.recipe.repository;
+
+import gnu.project.pbl2.recipe.entity.Favorite;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+    Optional<Favorite> findByUser_IdAndRecipe_Id(Long userId, Long recipeId);
+}

--- a/src/main/java/gnu/project/pbl2/recipe/service/FavoriteService.java
+++ b/src/main/java/gnu/project/pbl2/recipe/service/FavoriteService.java
@@ -14,6 +14,7 @@ import gnu.project.pbl2.recipe.repository.RecipeRepository;
 import gnu.project.pbl2.user.entity.User;
 import gnu.project.pbl2.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,17 +32,17 @@ public class FavoriteService {
     public void add(final Long recipeId, final Accessor accessor) {
         final Long userId = accessor.getUserId();
 
-        if (favoriteRepository.findByUser_IdAndRecipe_Id(userId, recipeId).isPresent()) {
-            throw new BusinessException(ErrorCode.FAVORITE_ALREADY_EXISTS);
-        }
-
         final Recipe recipe = recipeRepository.findById(recipeId)
             .orElseThrow(() -> new BusinessException(ErrorCode.RECIPE_NOT_FOUND));
 
         final User user = userRepository.findActiveById(userId)
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        favoriteRepository.save(Favorite.of(user, recipe));
+        try {
+            favoriteRepository.saveAndFlush(Favorite.of(user, recipe));
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.FAVORITE_ALREADY_EXISTS);
+        }
     }
 
     @Transactional

--- a/src/main/java/gnu/project/pbl2/recipe/service/FavoriteService.java
+++ b/src/main/java/gnu/project/pbl2/recipe/service/FavoriteService.java
@@ -1,0 +1,64 @@
+package gnu.project.pbl2.recipe.service;
+
+import gnu.project.pbl2.auth.entity.Accessor;
+import gnu.project.pbl2.common.error.ErrorCode;
+import gnu.project.pbl2.common.exception.BusinessException;
+import gnu.project.pbl2.recipe.dto.request.FavoriteListRequest;
+import gnu.project.pbl2.recipe.dto.request.RecipeSearchRequest;
+import gnu.project.pbl2.recipe.dto.response.RecipeSearchResponse;
+import gnu.project.pbl2.recipe.entity.Favorite;
+import gnu.project.pbl2.recipe.entity.Recipe;
+import gnu.project.pbl2.recipe.enumerated.RecipeTab;
+import gnu.project.pbl2.recipe.repository.FavoriteRepository;
+import gnu.project.pbl2.recipe.repository.RecipeRepository;
+import gnu.project.pbl2.user.entity.User;
+import gnu.project.pbl2.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final RecipeRepository recipeRepository;
+    private final UserRepository userRepository;
+    private final RecipeService recipeService;
+
+    @Transactional
+    public void add(final Long recipeId, final Accessor accessor) {
+        final Long userId = accessor.getUserId();
+
+        if (favoriteRepository.findByUser_IdAndRecipe_Id(userId, recipeId).isPresent()) {
+            throw new BusinessException(ErrorCode.FAVORITE_ALREADY_EXISTS);
+        }
+
+        final Recipe recipe = recipeRepository.findById(recipeId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.RECIPE_NOT_FOUND));
+
+        final User user = userRepository.findActiveById(userId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        favoriteRepository.save(Favorite.of(user, recipe));
+    }
+
+    @Transactional
+    public void remove(final Long recipeId, final Accessor accessor) {
+        final Long userId = accessor.getUserId();
+
+        final Favorite favorite = favoriteRepository.findByUser_IdAndRecipe_Id(userId, recipeId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.FAVORITE_NOT_FOUND));
+
+        favoriteRepository.delete(favorite);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<RecipeSearchResponse> getFavorites(final FavoriteListRequest request, final Accessor accessor) {
+        RecipeSearchRequest searchRequest = new RecipeSearchRequest(
+            request.keyword(), RecipeTab.FAVORITE, request.page(), request.size()
+        );
+        return recipeService.getRecipes(searchRequest, accessor);
+    }
+}

--- a/src/test/java/gnu/project/pbl2/notification/repository/SseEmitterRepositoryConcurrencyTest.java
+++ b/src/test/java/gnu/project/pbl2/notification/repository/SseEmitterRepositoryConcurrencyTest.java
@@ -1,0 +1,118 @@
+package gnu.project.pbl2.notification.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class SseEmitterRepositoryConcurrencyTest {
+
+    // SseEmitter.onCompletion() 콜백은 HTTP 핸들러 없이 동작하지 않으므로
+    // complete() 자체를 오버라이드해 호출 여부를 추적한다
+    static class TrackableEmitter extends SseEmitter {
+        final AtomicBoolean completed = new AtomicBoolean(false);
+
+        TrackableEmitter() {
+            super(1000L);
+        }
+
+        @Override
+        public void complete() {
+            completed.set(true);
+            super.complete();
+        }
+    }
+
+    private SseEmitterRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new SseEmitterRepository();
+    }
+
+    @Test
+    @DisplayName("같은 유저로 재연결 시 이전 이미터가 complete() 처리되어야 한다")
+    void 재연결_시_이전_이미터가_완료된다() {
+        Long userId = 1L;
+        TrackableEmitter first = new TrackableEmitter();
+        repository.save(userId, first);
+
+        SseEmitter second = new SseEmitter(1000L);
+        repository.save(userId, second);
+
+        assertThat(first.completed.get()).isTrue();
+        assertThat(repository.findById(userId)).hasValueSatisfying(e -> assertThat(e).isSameAs(second));
+    }
+
+    @Test
+    @DisplayName("동시에 저장 시 이전 이미터들이 모두 complete() 처리되고 하나만 남아야 한다")
+    void 동시에_저장_시_이전_이미터가_모두_완료된다() throws InterruptedException {
+        int threadCount = 10;
+        Long userId = 1L;
+        CopyOnWriteArrayList<TrackableEmitter> emitters = new CopyOnWriteArrayList<>();
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    TrackableEmitter emitter = new TrackableEmitter();
+                    emitters.add(emitter);
+                    repository.save(userId, emitter);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        endLatch.await();
+        executor.shutdown();
+
+        long completedCount = emitters.stream()
+            .filter(e -> e.completed.get())
+            .count();
+
+        // 10개 저장 시 최초 저장을 제외한 9개(threadCount - 1)의 이전 이미터가 완료되어야 함
+        assertThat(repository.findById(userId)).isPresent();
+        assertThat(completedCount).isEqualTo(threadCount - 1);
+    }
+
+    @Test
+    @DisplayName("서로 다른 유저의 이미터는 독립적으로 관리되어야 한다")
+    void 다른_유저_이미터는_독립적으로_관리된다() {
+        TrackableEmitter emitter1 = new TrackableEmitter();
+        TrackableEmitter emitter2 = new TrackableEmitter();
+
+        repository.save(1L, emitter1);
+        repository.save(2L, emitter2);
+
+        repository.delete(1L);
+
+        assertThat(repository.findById(1L)).isEmpty();
+        assertThat(repository.findById(2L)).isPresent();
+        assertThat(emitter2.completed.get()).isFalse();
+    }
+
+    @Test
+    @DisplayName("이미터 삭제 후 조회하면 비어있어야 한다")
+    void 이미터_삭제_후_조회_시_비어있다() {
+        Long userId = 1L;
+        repository.save(userId, new SseEmitter(1000L));
+        repository.delete(userId);
+
+        assertThat(repository.findById(userId)).isEmpty();
+    }
+}

--- a/src/test/java/gnu/project/pbl2/recipe/service/FavoriteServiceConcurrencyTest.java
+++ b/src/test/java/gnu/project/pbl2/recipe/service/FavoriteServiceConcurrencyTest.java
@@ -1,0 +1,114 @@
+package gnu.project.pbl2.recipe.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gnu.project.pbl2.auth.entity.Accessor;
+import gnu.project.pbl2.auth.enumerated.SocialProvider;
+import gnu.project.pbl2.common.entity.Category;
+import gnu.project.pbl2.common.entity.Taste;
+import gnu.project.pbl2.common.enumerated.UserRole;
+import gnu.project.pbl2.common.repository.CategoryRepository;
+import gnu.project.pbl2.common.repository.TasteRepository;
+import gnu.project.pbl2.recipe.entity.Recipe;
+import gnu.project.pbl2.recipe.repository.FavoriteRepository;
+import gnu.project.pbl2.recipe.repository.RecipeRepository;
+import gnu.project.pbl2.user.entity.User;
+import gnu.project.pbl2.user.repository.UserRepository;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class FavoriteServiceConcurrencyTest {
+
+    @Autowired FavoriteService favoriteService;
+    @Autowired FavoriteRepository favoriteRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired RecipeRepository recipeRepository;
+    @Autowired CategoryRepository categoryRepository;
+    @Autowired TasteRepository tasteRepository;
+
+    Long recipeId;
+    Accessor accessor;
+
+    @BeforeEach
+    void setUp() {
+        // data.sql로 삽입된 기존 데이터 사용 (새로 insert하면 PK 충돌 발생)
+        Category category = categoryRepository.findByName("한식").orElseThrow();
+        Taste taste = tasteRepository.findByName("매운맛").orElseThrow();
+        Recipe recipe = recipeRepository.save(
+            Recipe.create("테스트 레시피", category, taste, 30, "테스트 설명", "https://youtube.com")
+        );
+        recipeId = recipe.getId();
+
+        User user = userRepository.save(
+            User.createFromOAuth("test@test.com", "테스트유저", "test-social-" + System.nanoTime(), SocialProvider.KAKAO)
+        );
+        accessor = Accessor.user("test-social-id", user.getId(), UserRole.USER);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // data.sql 데이터(Category, Taste, Ingredient 등)는 건드리지 않음
+        favoriteRepository.deleteAll();
+        recipeRepository.deleteById(recipeId);
+        userRepository.deleteById(accessor.getUserId());
+    }
+
+    @Test
+    @DisplayName("동시에 즐겨찾기 추가 요청이 오면 하나만 저장되고 나머지는 실패해야 한다")
+    void 동시에_즐겨찾기_추가_시_하나만_저장된다() throws InterruptedException {
+        int threadCount = 5;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    favoriteService.add(recipeId, accessor);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        endLatch.await();
+        executor.shutdown();
+
+        assertThat(favoriteRepository.findAll()).hasSize(1);
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(threadCount - 1);
+    }
+
+    @Test
+    @DisplayName("즐겨찾기가 이미 존재하면 추가 시 예외가 발생해야 한다")
+    void 즐겨찾기_중복_추가_시_예외가_발생한다() {
+        favoriteService.add(recipeId, accessor);
+
+        AtomicInteger failCount = new AtomicInteger();
+
+        try {
+            favoriteService.add(recipeId, accessor);
+        } catch (Exception e) {
+            failCount.incrementAndGet();
+        }
+
+        assertThat(favoriteRepository.findAll()).hasSize(1);
+        assertThat(failCount.get()).isEqualTo(1);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,33 @@
+spring:
+  application:
+    name: pbl2
+  jpa:
+    open-in-view: false
+    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;NON_KEYWORDS=VALUE
+    username: sa
+    password:
+
+gemini:
+  api:
+    key: test-gemini-api-key
+
+jwt:
+  secret-key: test-jwt-secret-key-for-testing-purposes-this-must-be-at-least-256-bits-long
+  accessToken-expiration-millis: 86400000
+
+oauth:
+  kakao:
+    client-id: test-kakao-client-id
+    redirect-uri: http://localhost:3000/auth/kakao/callback
+    token-uri: https://kauth.kakao.com/oauth/token
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+    secret: test-kakao-secret
+
+fastapi:
+  base-url: http://localhost:8000


### PR DESCRIPTION


## 관련 이슈

> #26 

---

## 작업 내용

### 1. 즐겨찾기 기능 API 추가

* `POST /api/v1/recipes/{recipeId}/favorites`
  → 레시피 즐겨찾기 추가
* `DELETE /api/v1/recipes/{recipeId}/favorites`
  → 즐겨찾기 삭제
* `GET /api/v1/recipes/favorites`
  → 즐겨찾기 목록 조회 (페이지네이션 + 검색 지원)

---

### 2. Controller / Docs 구성

* `FavoriteController` 구현
* Swagger 문서화를 위한 `FavoriteDocs` 인터페이스 분리
* 인증 사용자만 접근 가능하도록 `@OnlyUser` 적용

---

### 3. Service 로직 구현

* 즐겨찾기 추가

  * 이미 존재 시 예외 처리
  * 레시피/유저 유효성 검증 후 저장

* 즐겨찾기 삭제

  * 존재하지 않을 경우 예외 처리

* 즐겨찾기 목록 조회

  * 기존 `RecipeService` 재사용
  * `RecipeTab.FAVORITE` 기반 조회

---

### 4. Repository 추가

* `FavoriteRepository` 생성
* `findByUser_IdAndRecipe_Id` 메서드로 중복 및 조회 처리

---

### 5. 요청 DTO 추가

* `FavoriteListRequest`

  * keyword 검색 지원
  * page, size 검증
  * size 기본값 10 처리

---

### 6. 예외 코드 추가

* `FAVORITE_ALREADY_EXISTS`
* `FAVORITE_NOT_FOUND`

---

## ETC

* 기존 레시피 조회 로직을 재사용하여 중복 코드 최소화
* 즐겨찾기 기능을 별도 탭(`RecipeTab.FAVORITE`)으로 확장 가능하게 설계
* 추후 좋아요 수, 인기순 정렬 등으로 확장 가능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 레시피 즐겨찾기 추가/삭제 및 즐겨찾기 목록 조회(페이지네이션·검색) API 제공
* **버그 수정 / 안정성**
  * 중복 즐겨찾기와 미존재 즐겨찾기에 대한 명확한 오류 코드 및 메시지 추가
  * 즐겨찾기·알림 중복 등록 방지(데이터 고유 제약)로 일관성 향상
  * 실시간 전송(Emitter) 동시성 처리 개선으로 기존 연결 안전하게 교체
* **문서**
  * 즐겨찾기 관련 API 설명(명세) 추가
* **테스트**
  * 동시성 및 동작 검증을 위한 단위/통합 테스트 추가
* **환경**
  * 테스트 실행을 위한 빌드 의존성 및 테스트 설정 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->