### PR TITLE
feat: EC2에서 서버컴 SSH 비밀번호 기반 CD로 전환

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,9 +57,9 @@ jobs:
           cache-from: type=gha,scope=fastapi
           cache-to: type=gha,scope=fastapi,mode=max
 
-  # ── EC2 배포 ──────────────────────────────────────────────
+  # ── 서버 배포 (SSH) ───────────────────────────────────────
   deploy:
-    name: EC2 배포
+    name: 서버 배포
     runs-on: ubuntu-latest
     needs: build-and-push
     permissions:
@@ -71,16 +71,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: docker-compose.prod.yml EC2 전송
+      - name: docker-compose.prod.yml 서버 전송
         uses: appleboy/scp-action@v0.1.7
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          port: ${{ secrets.SERVER_PORT }}
           source: docker-compose.prod.yml
           target: ~/pbl2/
 
-      - name: EC2 배포 실행
+      - name: 서버 배포 실행
         uses: appleboy/ssh-action@v1.0.3
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -92,12 +93,14 @@ jobs:
           KAKAO_REDIRECT_URI: ${{ secrets.KAKAO_REDIRECT_URI }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          port: ${{ secrets.SERVER_PORT }}
           envs: DOCKERHUB_USERNAME,DOCKERHUB_TOKEN,IMAGE_TAG,JWT_SECRET_KEY,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,GEMINI_API_KEY
           script: |
             set -e
+            mkdir -p ~/pbl2
             cd ~/pbl2
 
             # .env 파일 갱신

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,7 +11,6 @@ services:
       MYSQL_USER: pbl2
       MYSQL_PASSWORD: pbl2pass
       TZ: Asia/Seoul
-    # 운영: MySQL은 컨테이너 내부 네트워크만 사용, 호스트에 직접 노출하지 않음
     volumes:
       - mysql_data:/var/lib/mysql
     healthcheck:
@@ -20,16 +19,14 @@ services:
       timeout: 5s
       retries: 10
       start_period: 30s
+    networks:
+      - pbl2-network
     restart: unless-stopped
 
   fastapi:
-    # FASTAPI_IMAGE: CD에서 SHA 태그로 주입 (예: username/pbl2-fastapi:abc1234)
     image: ${FASTAPI_IMAGE}
     container_name: pbl2-fastapi
-    ports:
-      - "8000:8000"
     volumes:
-      # best.pt는 EC2에 ~/pbl2/best.pt 로 수동 업로드 필요
       - ./best.pt:/app/best.pt:ro
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/docs')"]
@@ -37,17 +34,18 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+    networks:
+      - pbl2-network
     restart: unless-stopped
 
   spring:
-    # SPRING_IMAGE: CD에서 SHA 태그로 주입 (예: username/pbl2-spring:abc1234)
     image: ${SPRING_IMAGE}
     container_name: pbl2-spring
     ports:
       - "8080:8080"
     environment:
       SPRING_PROFILES_ACTIVE: prod
-      DB_URL: jdbc:mysql://mysql:3306/pbl2?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      DB_URL: jdbc:mysql://pbl2-mysql:3306/pbl2?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       DB_USERNAME: pbl2
       DB_PASSWORD: pbl2pass
       JWT_SECRET_KEY: ${JWT_SECRET_KEY}
@@ -55,13 +53,19 @@ services:
       KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET}
       KAKAO_REDIRECT_URI: ${KAKAO_REDIRECT_URI}
       GEMINI_API_KEY: ${GEMINI_API_KEY}
-      FASTAPI_BASE_URL: http://fastapi:8000
+      FASTAPI_BASE_URL: http://pbl2-fastapi:8000
     depends_on:
       mysql:
         condition: service_healthy
       fastapi:
         condition: service_healthy
+    networks:
+      - pbl2-network
     restart: unless-stopped
+
+networks:
+  pbl2-network:
+    driver: bridge
 
 volumes:
   mysql_data:


### PR DESCRIPTION
- EC2_HOST/USER/SSH_KEY → SERVER_HOST/USER/PASSWORD/PORT로 변경
- pbl2-network(bridge) 도입으로 gaechuck 서버와 네트워크 격리
- fastapi/mysql 포트 호스트 노출 제거, spring만 8080 노출
- DB_URL 컨테이너명 mysql → pbl2-mysql 명시
- 배포 디렉토리 자동 생성(mkdir -p) 추가

## 관련 이슈

> #{ISSUE_NUMBER}

## 작업 내용


## ETC
> 참고할만한 링크 또는 메모



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 및 서버 접속 방식을 개선했습니다.
  * 컨테이너 간 통신 네트워크 구성을 강화했습니다.
  * 서비스 자동 재시작 정책을 추가하여 시스템 안정성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->