### PR TITLE
fix: FastAPI 헬스체크 start_period 30s→120s로 증가

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   mysql:
     image: mysql:8.0
@@ -31,9 +29,9 @@ services:
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/docs')"]
       interval: 15s
-      timeout: 5s
-      retries: 5
-      start_period: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
     networks:
       - pbl2-network
     restart: unless-stopped


### PR DESCRIPTION
YOLOv5 모델 다운로드 및 로드 시간이 30s를 초과해 헬스체크 실패.
start_period 120s, retries 10회, timeout 10s로 조정.
version 필드 obsolete 경고 제거.

## 관련 이슈

> #{ISSUE_NUMBER}

## 작업 내용


## ETC
> 참고할만한 링크 또는 메모

