### PR TITLE
fix: FastAPI 헬스체크 python → python3로 수정

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - ./best.pt:/app/best.pt:ro
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/docs')"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/docs')"]
       interval: 15s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
YOLOv5 이미지에 python 심볼릭링크가 없어 healthcheck 실패.
python3로 변경.

## 관련 이슈

> #{ISSUE_NUMBER}

## 작업 내용


## ETC
> 참고할만한 링크 또는 메모

