### PR TITLE
[Recipe] 레시피 재료 장바구니 추가 기능 구현

### DIFF
--- a/src/main/java/gnu/project/pbl2/cart/controller/CartController.java
+++ b/src/main/java/gnu/project/pbl2/cart/controller/CartController.java
@@ -1,0 +1,70 @@
+package gnu.project.pbl2.cart.controller;
+
+import gnu.project.pbl2.auth.aop.Auth;
+import gnu.project.pbl2.auth.aop.OnlyUser;
+import gnu.project.pbl2.auth.entity.Accessor;
+import gnu.project.pbl2.cart.controller.docs.CartDocs;
+import gnu.project.pbl2.cart.dto.request.CartItemAddBatchRequest;
+import gnu.project.pbl2.cart.dto.request.CartItemUpdateRequest;
+import gnu.project.pbl2.cart.dto.response.CartItemResponse;
+import gnu.project.pbl2.cart.service.CartService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/carts")
+public class CartController implements CartDocs {
+
+    private final CartService cartService;
+
+    @OnlyUser
+    @GetMapping("/items")
+    public ResponseEntity<List<CartItemResponse>> getItems(@Auth final Accessor accessor) {
+        return ResponseEntity.ok(cartService.getItems(accessor));
+    }
+
+    @OnlyUser
+    @PostMapping("/items")
+    public ResponseEntity<List<CartItemResponse>> addItems(
+        @Auth final Accessor accessor,
+        @Valid @RequestBody final CartItemAddBatchRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(cartService.addItems(accessor, request));
+    }
+
+    @OnlyUser
+    @PatchMapping("/items/{cartItemId}")
+    public ResponseEntity<CartItemResponse> updateItem(
+        @PathVariable final Long cartItemId,
+        @Valid @RequestBody final CartItemUpdateRequest request
+    ) {
+        return ResponseEntity.ok(cartService.updateItem(cartItemId, request));
+    }
+
+    @OnlyUser
+    @DeleteMapping("/items/{cartItemId}")
+    public ResponseEntity<Void> deleteItem(@PathVariable final Long cartItemId) {
+        cartService.deleteItem(cartItemId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @OnlyUser
+    @DeleteMapping("/items")
+    public ResponseEntity<Void> deleteItems(@RequestBody final List<Long> cartItemIds) {
+        cartService.deleteItems(cartItemIds);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/gnu/project/pbl2/cart/controller/docs/CartDocs.java
+++ b/src/main/java/gnu/project/pbl2/cart/controller/docs/CartDocs.java
@@ -1,0 +1,29 @@
+package gnu.project.pbl2.cart.controller.docs;
+
+import gnu.project.pbl2.auth.entity.Accessor;
+import gnu.project.pbl2.cart.dto.request.CartItemAddBatchRequest;
+import gnu.project.pbl2.cart.dto.request.CartItemUpdateRequest;
+import gnu.project.pbl2.cart.dto.response.CartItemResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Cart", description = "장바구니 API")
+public interface CartDocs {
+
+    @Operation(summary = "장바구니 목록 조회")
+    ResponseEntity<List<CartItemResponse>> getItems(Accessor accessor);
+
+    @Operation(summary = "장바구니 재료 일괄 추가 (같은 이름이면 수량 합산)")
+    ResponseEntity<List<CartItemResponse>> addItems(Accessor accessor, CartItemAddBatchRequest request);
+
+    @Operation(summary = "장바구니 항목 수정 (수량 또는 체크 상태)")
+    ResponseEntity<CartItemResponse> updateItem(Long cartItemId, CartItemUpdateRequest request);
+
+    @Operation(summary = "장바구니 항목 단건 삭제")
+    ResponseEntity<Void> deleteItem(Long cartItemId);
+
+    @Operation(summary = "장바구니 항목 일괄 삭제")
+    ResponseEntity<Void> deleteItems(List<Long> cartItemIds);
+}

--- a/src/main/java/gnu/project/pbl2/cart/dto/request/CartItemAddBatchRequest.java
+++ b/src/main/java/gnu/project/pbl2/cart/dto/request/CartItemAddBatchRequest.java
@@ -1,0 +1,9 @@
+package gnu.project.pbl2.cart.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record CartItemAddBatchRequest(
+    @NotEmpty @Valid List<CartItemAddRequest> items
+) {}

--- a/src/main/java/gnu/project/pbl2/cart/dto/request/CartItemAddRequest.java
+++ b/src/main/java/gnu/project/pbl2/cart/dto/request/CartItemAddRequest.java
@@ -1,0 +1,12 @@
+package gnu.project.pbl2.cart.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CartItemAddRequest(
+    Long ingredientId,       // 레시피 재료 ID (직접 입력 시 null 허용)
+    @NotBlank String name,
+    @NotNull @Min(1) Integer quantity,
+    String unit
+) {}

--- a/src/main/java/gnu/project/pbl2/cart/dto/request/CartItemUpdateRequest.java
+++ b/src/main/java/gnu/project/pbl2/cart/dto/request/CartItemUpdateRequest.java
@@ -1,0 +1,8 @@
+package gnu.project.pbl2.cart.dto.request;
+
+import jakarta.validation.constraints.Min;
+
+public record CartItemUpdateRequest(
+    @Min(1) Integer quantity,   // null이면 수정 안 함
+    Boolean isChecked           // null이면 수정 안 함
+) {}

--- a/src/main/java/gnu/project/pbl2/cart/dto/response/CartItemResponse.java
+++ b/src/main/java/gnu/project/pbl2/cart/dto/response/CartItemResponse.java
@@ -1,0 +1,23 @@
+package gnu.project.pbl2.cart.dto.response;
+
+import gnu.project.pbl2.cart.entity.CartItem;
+
+public record CartItemResponse(
+    Long cartItemId,
+    Long ingredientId,
+    String name,
+    Integer quantity,
+    String unit,
+    boolean isChecked
+) {
+    public static CartItemResponse from(CartItem item) {
+        return new CartItemResponse(
+            item.getCartItemId(),
+            item.getIngredientId(),
+            item.getName(),
+            item.getQuantity(),
+            item.getUnit(),
+            item.isChecked()
+        );
+    }
+}

--- a/src/main/java/gnu/project/pbl2/cart/entity/CartItem.java
+++ b/src/main/java/gnu/project/pbl2/cart/entity/CartItem.java
@@ -1,0 +1,89 @@
+package gnu.project.pbl2.cart.entity;
+
+import gnu.project.pbl2.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cart_item")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CartItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cart_item_id")
+    private Long cartItemId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", referencedColumnName = "member_id", nullable = false)
+    private User member;
+
+    // 마스터 재료 ID (레시피에서 추가된 경우 존재, 직접 입력 시 null)
+    @Column(name = "ingredient_id")
+    private Long ingredientId;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Column(name = "unit", length = 20)
+    private String unit;
+
+    @Column(name = "is_checked", nullable = false)
+    private boolean isChecked;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    private CartItem(
+        final User member,
+        final Long ingredientId,
+        final String name,
+        final Integer quantity,
+        final String unit
+    ) {
+        this.member = member;
+        this.ingredientId = ingredientId;
+        this.name = name;
+        this.quantity = quantity;
+        this.unit = unit;
+        this.isChecked = false;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public static CartItem create(
+        final User member,
+        final Long ingredientId,
+        final String name,
+        final Integer quantity,
+        final String unit
+    ) {
+        return new CartItem(member, ingredientId, name, quantity, unit);
+    }
+
+    public void addQuantity(final int delta) {
+        this.quantity += delta;
+    }
+
+    public void updateQuantity(final int quantity) {
+        this.quantity = quantity;
+    }
+
+    public void updateChecked(final boolean isChecked) {
+        this.isChecked = isChecked;
+    }
+}

--- a/src/main/java/gnu/project/pbl2/cart/repository/CartItemRepository.java
+++ b/src/main/java/gnu/project/pbl2/cart/repository/CartItemRepository.java
@@ -1,0 +1,13 @@
+package gnu.project.pbl2.cart.repository;
+
+import gnu.project.pbl2.cart.entity.CartItem;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+
+    List<CartItem> findAllByMember_IdOrderByCreatedAtAsc(Long memberId);
+
+    Optional<CartItem> findByMember_IdAndName(Long memberId, String name);
+}

--- a/src/main/java/gnu/project/pbl2/cart/service/CartService.java
+++ b/src/main/java/gnu/project/pbl2/cart/service/CartService.java
@@ -1,0 +1,96 @@
+package gnu.project.pbl2.cart.service;
+
+import gnu.project.pbl2.auth.entity.Accessor;
+import gnu.project.pbl2.cart.dto.request.CartItemAddBatchRequest;
+import gnu.project.pbl2.cart.dto.request.CartItemAddRequest;
+import gnu.project.pbl2.cart.dto.request.CartItemUpdateRequest;
+import gnu.project.pbl2.cart.dto.response.CartItemResponse;
+import gnu.project.pbl2.cart.entity.CartItem;
+import gnu.project.pbl2.cart.repository.CartItemRepository;
+import gnu.project.pbl2.common.error.ErrorCode;
+import gnu.project.pbl2.common.exception.BusinessException;
+import gnu.project.pbl2.user.entity.User;
+import gnu.project.pbl2.user.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CartService {
+
+    private final CartItemRepository cartItemRepository;
+    private final UserRepository userRepository;
+
+    public List<CartItemResponse> getItems(final Accessor accessor) {
+        return cartItemRepository
+            .findAllByMember_IdOrderByCreatedAtAsc(accessor.getUserId())
+            .stream()
+            .map(CartItemResponse::from)
+            .toList();
+    }
+
+    @Transactional
+    public List<CartItemResponse> addItems(
+        final Accessor accessor,
+        final CartItemAddBatchRequest request
+    ) {
+        final User member = userRepository.findById(accessor.getUserId())
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return request.items().stream()
+            .map(req -> upsertItem(member, req))
+            .map(CartItemResponse::from)
+            .toList();
+    }
+
+    // 같은 이름의 항목이 이미 있으면 수량만 합산, 없으면 신규 생성
+    private CartItem upsertItem(final User member, final CartItemAddRequest req) {
+        return cartItemRepository
+            .findByMember_IdAndName(member.getId(), req.name())
+            .map(existing -> {
+                existing.addQuantity(req.quantity());
+                return existing;
+            })
+            .orElseGet(() -> cartItemRepository.save(
+                CartItem.create(
+                    member,
+                    req.ingredientId(),
+                    req.name(),
+                    req.quantity(),
+                    req.unit()
+                )
+            ));
+    }
+
+    @Transactional
+    public CartItemResponse updateItem(
+        final Long cartItemId,
+        final CartItemUpdateRequest request
+    ) {
+        final CartItem item = cartItemRepository.findById(cartItemId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
+
+        if (request.quantity() != null) {
+            item.updateQuantity(request.quantity());
+        }
+        if (request.isChecked() != null) {
+            item.updateChecked(request.isChecked());
+        }
+        return CartItemResponse.from(item);
+    }
+
+    @Transactional
+    public void deleteItem(final Long cartItemId) {
+        final CartItem item = cartItemRepository.findById(cartItemId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
+        cartItemRepository.delete(item);
+    }
+
+    @Transactional
+    public void deleteItems(final List<Long> cartItemIds) {
+        cartItemRepository.deleteAllById(cartItemIds);
+    }
+}

--- a/src/main/java/gnu/project/pbl2/common/error/ErrorCode.java
+++ b/src/main/java/gnu/project/pbl2/common/error/ErrorCode.java
@@ -47,6 +47,9 @@ public enum ErrorCode {
     FRIDGE_NOT_FOUND(HttpStatus.NOT_FOUND,"FRIDGE9001" ,"냉장고를 찾을 수 없습니다" ),
     RECIPE_INGREDIENT_NOT_FOUND(HttpStatus.NOT_FOUND,"RECIPE_INGREDENT1001" ,"레시피 재료를 찾을 수 없습니다"),
 
+    // cart
+    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "CART1001", "해당 장바구니 항목을 찾을 수 없습니다."),
+
     // yolo
     YOLO_DETECT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "YOLO1001", "재료 감지에 실패했습니다."),
     YOLO_INVALID_IMAGE(HttpStatus.BAD_REQUEST, "YOLO1002", "이미지 파일만 업로드 가능합니다.");

--- a/src/main/java/gnu/project/pbl2/recipe/dto/request/RecipeSearchRequest.java
+++ b/src/main/java/gnu/project/pbl2/recipe/dto/request/RecipeSearchRequest.java
@@ -12,7 +12,7 @@ public record RecipeSearchRequest(
     @Min(0) int page,
     @Min(6) @Max(20) int size,
 
-    boolean usePreference
+    Boolean usePreference
 
 ) {
 
@@ -22,6 +22,9 @@ public record RecipeSearchRequest(
         }
         if (size == 0) {
             size = 10;
+        }
+        if (usePreference == null) {
+            usePreference = true;
         }
     }
 }

--- a/src/main/java/gnu/project/pbl2/recipe/dto/response/RecipeSearchResponse.java
+++ b/src/main/java/gnu/project/pbl2/recipe/dto/response/RecipeSearchResponse.java
@@ -1,27 +1,37 @@
 package gnu.project.pbl2.recipe.dto.response;
 
+import gnu.project.pbl2.fridge.enumerated.FridgeStatus;
+import java.util.List;
 
 public record RecipeSearchResponse(
     Long id,
     String title,
     String thumbnailUrl,
     Integer cookTimeMin,
-    boolean cookable,               // "조리가능" 뱃지
-    int expiringIngredientCount,    // "임박재료 N개" 뱃지
-    boolean isFavorite                // 하트 채움 여부
+    boolean cookable,
+    int expiringIngredientCount,
+    boolean isFavorite,
+    List<IngredientSummary> ingredients
 ) {
-    // 1단계: 레시피 기본 정보만으로 생성 (뱃지는 기본값)
+    public record IngredientSummary(
+        Long ingredientId,
+        String name,
+        FridgeStatus fridgeStatus
+    ) {}
+
     public static RecipeSearchResponse ofBase(
         Long id, String title, String thumbnailUrl, Integer cookTimeMin
     ) {
-        return new RecipeSearchResponse(id, title, thumbnailUrl, cookTimeMin, false, 0, false);
+        return new RecipeSearchResponse(id, title, thumbnailUrl, cookTimeMin, false, 0, false, List.of());
     }
 
-    // 2단계: 뱃지 정보 조립
-    public RecipeSearchResponse withBadge(boolean cookable, int expiringCount, boolean favorite) {
+    public RecipeSearchResponse withBadgeAndIngredients(
+        boolean cookable, int expiringCount, boolean favorite,
+        List<IngredientSummary> ingredients
+    ) {
         return new RecipeSearchResponse(
             this.id, this.title, this.thumbnailUrl, this.cookTimeMin,
-            cookable, expiringCount, favorite
+            cookable, expiringCount, favorite, ingredients
         );
     }
 }

--- a/src/main/java/gnu/project/pbl2/recipe/repository/impl/RecipeCustomRepositoryImpl.java
+++ b/src/main/java/gnu/project/pbl2/recipe/repository/impl/RecipeCustomRepositoryImpl.java
@@ -1,7 +1,5 @@
 package gnu.project.pbl2.recipe.repository.impl;
 
-import static com.querydsl.core.types.dsl.Expressions.asBoolean;
-import static com.querydsl.core.types.dsl.Expressions.asNumber;
 import static gnu.project.pbl2.fridge.entity.QFridge.fridge;
 import static gnu.project.pbl2.recipe.entity.QFavorite.favorite;
 import static gnu.project.pbl2.recipe.entity.QRecipe.recipe;
@@ -12,7 +10,6 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.SubQueryExpression;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
@@ -140,22 +137,22 @@ public class RecipeCustomRepositoryImpl implements RecipeCustomRepository {
         OrderSpecifier<?>... orders
     ) {
         List<RecipeSearchResponse> content = queryFactory
-            .select(Projections.constructor(RecipeSearchResponse.class,
-                recipe.id,
-                recipe.title,
-                recipe.thumbnailUrl,
-                recipe.cookTimeMin,
-                asBoolean(false),
-                asNumber(0).intValue(),
-                asBoolean(false)
-            ))
+            .select(recipe.id, recipe.title, recipe.thumbnailUrl, recipe.cookTimeMin)
             .from(recipe)
             .leftJoin(recipe.category)
             .where(condition, recipe.isDeleted.isFalse())
             .orderBy(orders)
             .offset((long) request.page() * request.size())
             .limit(request.size())
-        .fetch();
+            .fetch()
+            .stream()
+            .map(t -> RecipeSearchResponse.ofBase(
+                t.get(recipe.id),
+                t.get(recipe.title),
+                t.get(recipe.thumbnailUrl),
+                t.get(recipe.cookTimeMin)
+            ))
+            .toList();
 
         long total = queryFactory
             .select(recipe.count())

--- a/src/main/java/gnu/project/pbl2/recipe/service/RecipeService.java
+++ b/src/main/java/gnu/project/pbl2/recipe/service/RecipeService.java
@@ -36,6 +36,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -80,12 +81,31 @@ public class RecipeService {
         Map<Long, Long> expiringMap = recipeRepository.findExpiringCountMap(recipeIds, userId);
         Set<Long> favoriteIds = recipeRepository.findFavoriteRecipeIds(recipeIds, userId);
 
+        Set<Long> myIngredientIds = fridgeRepository.findIngredientIdsByUserId(userId);
+        Set<Long> expiringIngredientIds = fridgeRepository.findExpiringIngredientIds(
+            userId, LocalDate.now().plusDays(3));
+
+        Map<Long, List<RecipeIngredient>> ingredientsByRecipe =
+            recipeIngredientRepository.findAllById_RecipeIdIn(recipeIds).stream()
+                .collect(Collectors.groupingBy(RecipeIngredient::getRecipeId));
+
         List<RecipeSearchResponse> assembled = page.getContent().stream()
-            .map(r -> r.withBadge(
-                cookableIds.contains(r.id()),
-                expiringMap.getOrDefault(r.id(), 0L).intValue(),
-                favoriteIds.contains(r.id())
-            ))
+            .map(r -> {
+                List<RecipeSearchResponse.IngredientSummary> summaries =
+                    ingredientsByRecipe.getOrDefault(r.id(), List.of()).stream()
+                        .map(ri -> new RecipeSearchResponse.IngredientSummary(
+                            ri.getIngredientId(),
+                            ri.getIngredient().getName(),
+                            getFridgeStatus(ri.getIngredientId(), myIngredientIds, expiringIngredientIds)
+                        ))
+                        .toList();
+                return r.withBadgeAndIngredients(
+                    cookableIds.contains(r.id()),
+                    expiringMap.getOrDefault(r.id(), 0L).intValue(),
+                    favoriteIds.contains(r.id()),
+                    summaries
+                );
+            })
             .toList();
 
         return new PageImpl<>(assembled, page.getPageable(), page.getTotalElements());

--- a/src/main/java/gnu/project/pbl2/recipeingredient/repository/RecipeIngredientRepository.java
+++ b/src/main/java/gnu/project/pbl2/recipeingredient/repository/RecipeIngredientRepository.java
@@ -2,6 +2,7 @@ package gnu.project.pbl2.recipeingredient.repository;
 
 import gnu.project.pbl2.recipeingredient.entity.RecipeIngredient;
 import gnu.project.pbl2.recipeingredient.entity.RecipeIngredientId;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -20,6 +21,10 @@ public interface RecipeIngredientRepository extends JpaRepository<RecipeIngredie
         Long recipeId,
         Long ingredientId
     );
+
+    /** 여러 레시피의 재료 일괄 조회 */
+    @EntityGraph(attributePaths = "ingredient")
+    List<RecipeIngredient> findAllById_RecipeIdIn(Collection<Long> recipeIds);
 
     /** 중복 확인 */
     boolean existsById_RecipeIdAndId_IngredientId(Long recipeId, Long ingredientId);


### PR DESCRIPTION
## 관련 이슈

> #46 

## 작업 내용
- 레시피 검색 응답에 재료 요약 추가 및 서비스 로직 수정
- 장바구니 API 구현 및 관련 DTO, 서비스, 레포지토리 추가

## ETC
> 참고할만한 링크 또는 메모



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive cart management functionality: view, add, update, and delete cart items.
  * Enhanced recipe search results to display ingredient information, including availability status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->